### PR TITLE
Put the growl_notify in a try

### DIFF
--- a/ads2bibdesk.py
+++ b/ads2bibdesk.py
@@ -385,7 +385,10 @@ def notify(title, subtitle, desc, sticky=False):
         # revert to growl
         if subtitle:
             desc = subtitle + ': ' + desc
-        growl_notify(title, desc, sticky)
+        try:
+            growl_notify(title, desc, sticky)
+        except:
+            pass
 
 def has_annotationss(f):
     """


### PR DESCRIPTION
To avoid unnecessary crash when growl is not installed, the growl_notify is encapsulated in a try block.