### PR TITLE
Fix article_esources assignment to handle None

### DIFF
--- a/ads2bibdesk/ads2bibdesk.py
+++ b/ads2bibdesk/ads2bibdesk.py
@@ -366,7 +366,7 @@ def process_token(article_identifier, prefs, bibdesk, skip_bibcode=False):
     logger.debug("{}".format(ads_bibtex))
 
     article_bibcode = ads_article.bibcode
-    article_esources = ads_article.esources
+    article_esources = [] if ads_article.esources is None else ads_article.esources
 
     if 'true' in prefs['options']['download_pdf'].lower():
         pdf_filename, pdf_status = process_pdf(article_bibcode, article_esources, prefs=prefs)


### PR DESCRIPTION
Make sure that `article_esources` is always syntactically a list, even if it is empty. This fixes a crash with bibcodes (such as 1929PDAO....4..209Z) where the `ads.SearchQuery` returns `None` for `'esources'`